### PR TITLE
Clean up display for Hierarchy

### DIFF
--- a/src/components/AccountHierarchyTree.component
+++ b/src/components/AccountHierarchyTree.component
@@ -52,7 +52,7 @@
                 <apex:image id="Icon_child_current" url="/img/icon/star16.png" width="16" height="16" rendered="{!IF(pos.currentNode,true,false)}"/>
             </apex:outputText>
             <apex:outputText rendered="{!IF(pos.nodeType=='end',true,false)}">
-                <apex:image id="Tree_end" url="/img/tree/nodeEnd.gif" height="16" width="20"/>&nbsp;
+                <apex:image id="Tree_end" url="/img/tree/nodeEnd.gif" height="16" width="20"/>
                 <apex:image id="Icon_end" url="/img/icon/desk16.png" width="16" height="16" rendered="{!IF(pos.currentNode,false,true)}"/>
                 <apex:image id="Icon_end_current" url="/img/icon/star16.png" width="16" height="16" rendered="{!IF(pos.currentNode,true,false)}"/>
             </apex:outputText>

--- a/src/pages/AccountHierarchyPage.page
+++ b/src/pages/AccountHierarchyPage.page
@@ -17,7 +17,7 @@
 -->
 
 <apex:page standardController="account" tabStyle="Account" > 
-    <div style="height: 200px" class="bodyDiv" onclick="resizeFrame();">
+    <div style="height: 100%" class="bodyDiv" onclick="resizeFrame();">
         <c:AccountHierarchyTree currentId="{!Account.id}" />
     </div>
 </apex:page>


### PR DESCRIPTION
200px limit makes the bottom line not appear correctly.  100% works great on Chrome and Firefox.

By removing the &nbsp; in the end node, the Account lines up vertically with the others.
